### PR TITLE
Fix handling of .hugo_build.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ temp/
 
 # Hugo files and directories #
 ##############################
+.hugo_build.lock
 resources/
 docs/
 # local Hugo configuration to set the base URL to a local folder

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ SRC_DIR = markdown
 ## Top level directory for temporary files
 TEMP_DIR      = temp
 HUGO_TEMP_DIR = resources
+HUGO_LOCK     = .hugo_build.lock
 
 ## Top level directory for generated image files
 IMAGES_OUTPUT_DIR = $(TEMP_DIR)/images
@@ -205,7 +206,7 @@ clean-all: clean-temp ## Clean up all generated files and directories
 
 .PHONY: clean-temp
 clean-temp: ## Clean up all intermediate files and directories
-	rm -rf $(TEMP_DIR) $(HUGO_TEMP_DIR)
+	rm -rf $(TEMP_DIR) $(HUGO_TEMP_DIR) $(HUGO_LOCK)
 
 .PHONY: distclean
 distclean: clean-all ## Same as clean-all


### PR DESCRIPTION
Scheinbar wird beim Ausführen von Hugo in der nativen Installation eine Lock-Datei `.hugo_build.lock` angelegt. Damit diese nicht versehentlich eingecheckt wird, sollte sie im `.gitignore` sein und bei `make clean-temp` (bzw. `make clean`) mit weggeräumt werden.